### PR TITLE
Revert gh-29

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -20,7 +20,7 @@ cleanup || true
 
 
 docker build -t $IMAGE  .
-docker run -d --name $PREFIX-db -e POSTGRES_PASSWORD=postgres postgres:9.6.13
+docker run -d --name $PREFIX-db -e POSTGRES_PASSWORD=postgres postgres:10
 docker run -d --name $PREFIX-server --link $PREFIX-db:db \
     -p 4063:4063 -p 4064:4064 \
     -e CONFIG_omero_db_user=postgres \


### PR DESCRIPTION
Reverts gh-29 since the upstream PostgreSQL issue is now fixed. See https://github.com/ome/omero-install/issues/212 for more information.