### PR TITLE
Bump omero-server role to 2.1.0

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -7,6 +7,7 @@
     omero_server_database_manage: False
     omero_server_systemd_setup: False
     omero_server_system_uid: 1000
+    omero_server_virtualenv: True
     # You can reduce the size of the image by providing the URL to a
     # precompiled Ice Python wheel
     #ice_python_wheel:

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,6 +1,6 @@
 - hosts: localhost
   roles:
-  - role: openmicroscopy.omero-server
+  - role: ome.omero_server
   vars:
     ice_version: "3.6"
     ice_install_devel: False

--- a/requirements.yml
+++ b/requirements.yml
@@ -19,7 +19,7 @@
   version: 1.1.0
 
 - src: openmicroscopy.omero-server
-  version: 2.0.1
+  version: 2.1.0
 
 - src: openmicroscopy.postgresql
   version: 3.0.1

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,25 +1,25 @@
 # External Ansible roles required by this repository
 
-- src: openmicroscopy.basedeps
-  version: 1.0.0
-
-- src: openmicroscopy.ice
-  version: 2.1.1
-
-- src: openmicroscopy.java
-  version: 2.0.1
-
-- src: openmicroscopy.omego
-  version: 0.1.1
-
-- src: openmicroscopy.omero-common
-  version: 0.1.0
-
-- src: openmicroscopy.omero-python-deps
+- src: ome.basedeps
   version: 1.1.0
 
-- src: openmicroscopy.omero-server
+- src: ome.ice
+  version: 3.0.0
+
+- src: ome.java
+  version: 2.0.3
+
+- src: ome.omego
+  version: 0.1.3
+
+- src: ome.omero_common
+  version: 0.3.2
+
+- src: ome.omero_python_deps
+  version: 2.0.1
+
+- src: ome.omero_server
   version: 2.1.0
 
-- src: openmicroscopy.postgresql
-  version: 3.0.1
+- src: ome.postgresql
+  version: 3.3.1


### PR DESCRIPTION
In order to have a virtualenv in the runtime image for the openmicroscopy [Dockerfile](https://github.com/ome/openmicroscopy/blob/065226d60d668f208d1a55026414c20631796788/Dockerfile) (e.g. in https://github.com/ome/openmicroscopy/pull/6118), this bumps the `omero-server` ansible role to 2.1.0 and sets the virtualenv property to True.

see: https://github.com/ome/ansible-role-omero-server/pull/36