### PR TITLE
Disable rewrite

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/usr/local/bin/dumb-init /bin/bash
 
 set -e
+source /opt/omero/server/venv3/bin/activate
 
 for f in /startup/*; do
     if [ -f "$f" -a -x "$f" ]; then

--- a/playbook.yml
+++ b/playbook.yml
@@ -10,3 +10,4 @@
     omero_server_system_uid: 1000
     omero_server_virtualenv: True
     omero_server_python3: True
+    omero_server_python3_replace_omero: False

--- a/requirements.yml
+++ b/requirements.yml
@@ -16,8 +16,8 @@
   version: 2.0.1
 
 - name: ome.omero_server
-  src: https://github.com/ome/ansible-role-omero-server/archive/06bd02493b0afd5ee2c74f773fbb08b550ed82a2.tar.gz
-  version: 06bd02493b0afd5ee2c74f773fbb08b550ed82a2
+  src: https://github.com/ome/ansible-role-omero-server/archive/605fe70f3a93e1fb4accfc485a5a6359d28181f0.tar.gz
+  version: 605fe70f3a93e1fb4accfc485a5a6359d28181f0
 
 - src: ome.postgresql
   version: 3.3.1


### PR DESCRIPTION
The previous attempt on #33 to not overwrite bin/omero was likely missing `replace_omero: False`. The previous commit(s) as well as the flag are now applied. Propose to release this as `5.6.0-m1-3`.