### PR TITLE
Bump versions, Java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN ansible-playbook playbook.yml \
     -e omero_server_omego_additional_args="$OMEGO_ADDITIONAL_ARGS"
 
 RUN curl -L -o /usr/local/bin/dumb-init \
-    https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 && \
+    https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 && \
     chmod +x /usr/local/bin/dumb-init
 ADD entrypoint.sh /usr/local/bin/
 ADD 50-config.py 60-database.sh 99-run.sh /startup/

--- a/playbook.yml
+++ b/playbook.yml
@@ -2,9 +2,7 @@
   roles:
   - role: ome.omero_server
   vars:
-    ice_version: "3.6"
-    ice_install_devel: False
-    ice_install_python: False
+    java_versions: ["11"]
     omero_server_database_manage: False
     omero_server_systemd_setup: False
     omero_server_system_uid: 1000

--- a/requirements.yml
+++ b/requirements.yml
@@ -13,8 +13,8 @@
   version: 0.3.2
 
 - name: ome.omero_server
-  src: https://github.com/ome/ansible-role-omero-server/archive/d67a65f1617d1e8658444ba0f972540237f32d1c.tar.gz
-  version: d67a65f1617d1e8658444ba0f972540237f32d1c
+  src: https://github.com/ome/ansible-role-omero-server/archive/19747f05bba640df9f562fd95b1cae655ebe8e0c.tar.gz
+  version: 19747f05bba640df9f562fd95b1cae655ebe8e0c
 
 - src: ome.postgresql
   version: 3.3.1

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,16 +4,13 @@
   version: 1.1.0
 
 - src: ome.ice
-  version: 3.1.0
+  version: 4.0.0
 
 - src: ome.java
-  version: 2.0.3
+  version: 2.1.0
 
 - src: ome.omero_common
   version: 0.3.2
-
-- src: ome.omero_python_deps
-  version: 2.0.1
 
 - name: ome.omero_server
   src: https://github.com/ome/ansible-role-omero-server/archive/d67a65f1617d1e8658444ba0f972540237f32d1c.tar.gz

--- a/requirements.yml
+++ b/requirements.yml
@@ -16,8 +16,8 @@
   version: 2.0.1
 
 - name: ome.omero_server
-  src: https://github.com/ome/ansible-role-omero-server/archive/0eaeba62a9ec5f54a68522b6c79d6f5288ec927e.tar.gz
-  version: 0eaeba62a9ec5f54a68522b6c79d6f5288ec927e
+  src: https://github.com/ome/ansible-role-omero-server/archive/d67a65f1617d1e8658444ba0f972540237f32d1c.tar.gz
+  version: d67a65f1617d1e8658444ba0f972540237f32d1c
 
 - src: ome.postgresql
   version: 3.3.1


### PR DESCRIPTION
Main change is switching to Java 11 to match https://docs.openmicroscopy.org/omero/5.6.0-m4/sysadmins/version-requirements.html#java

Bump roles, and dumb-init

Ansible role diff:
```diff
diff --git a/.travis.yml b/.travis.yml
index c76547e..d64a751 100644
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   - SCENARIO=newdep
   - SCENARIO=olddep
   - SCENARIO=python3
+  - SCENARIO=upgrade-py2py3
   - SCENARIO=upgradetovenv
 
 notifications:
diff --git a/defaults/main.yml b/defaults/main.yml
index 1b9177e..e80d9bf 100644
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -87,16 +87,14 @@ omero_server_database_backupdir: ""
 # List of Python3 packages to install
 # _omero_* are temporary overrides pending a final release
 # Can't leave this unset because pip won't install the Python 3 pre-releases
-_omero_py_version: '5.6.dev9'
-_omero_dropbox_version: '5.6.dev3'
+_omero_py_version: '>=5.6.dev9'
+_omero_dropbox_version: '>=5.6.dev3'
 omero_server_python_requirements:
   - omego==0.7.0
   # TODO: make the use of our non-standard wheel optional
   - https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.2.1/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl
-  - "omero-py{{ (_omero_py_version | length > 0) |
-      ternary('==' + _omero_py_version, '') }}"
-  - "omero-dropbox{{ (_omero_dropbox_version | length > 0) |
-      ternary('==' + _omero_dropbox_version, '') }}"
+  - "omero-py{{ _omero_py_version | default('') }}"
+  - "omero-dropbox{{ _omero_dropbox_version  | default('') }}"
   # TODO: keep or ditch ipython? It's a big dependency and mostly useful for
   # clients
   # - ipython
@@ -120,6 +118,16 @@ omero_server_omerodir: "{{ omero_server_basedir }}/{{ omero_server_symlink }}"
 # How to run omero
 omero_server_omero_command: "{{ omero_server_omerodir }}/bin/omero"
 
+# Config update command
+omero_server_config_update: >-
+  {{
+    omero_server_python3 | ternary(
+      omero_server_omero_command + ' load --glob ' + omero_server_basedir +
+      '/config/*.omero',
+      omero_server_basedir + '/config/omero-server-config-update.sh'
+    )
+  }}
+
 # Need to set OMERODIR when omego runs omero
 omero_server_omego_environment: >-
   {{
diff --git a/handlers/main.yml b/handlers/main.yml
index fa99a37..e740b16 100644
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,7 +7,7 @@
 - name: omero-server rewrite omero-server configuration
   become: true
   become_user: "{{ omero_server_system_user }}"
-  command: "{{ omero_server_basedir }}/config/omero-server-config-update.sh"
+  command: "{{ omero_server_config_update }}"
 
 - name: omero-server restart omero-server
   become: true
diff --git a/meta/main.yml b/meta/main.yml
index b25b90e..df77f49 100644
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Install and configure OMERO.server, and optionally PostgreSQL
   company: Open Microscopy Environment
   license: BSD
-  min_ansible_version: 2.2
+  min_ansible_version: 2.6
   platforms:
     - name: EL
       versions:
@@ -21,10 +21,10 @@ dependencies:
   - role: ome.omero_python_deps
     when: not omero_server_python3
   - role: ome.ice
-    ice_version: "{{ omero_server_ice_version }}"
-    # TODO: For whatever reason this doesn't work, you must put these in your
-    # playbook instead
-    # ice_install_devel: not omero_server_python3
-    # ice_install_python: not omero_server_python3
+    vars:
+      ice_version: "{{ omero_server_ice_version }}"
+      ice_install_devel: "{{ not omero_server_python3 }}"
+      ice_install_python: "{{ not omero_server_python3 }}"
   - role: ome.postgresql
-    postgresql_install_server: false
+    vars:
+      postgresql_install_server: false
diff --git a/molecule/newdep/molecule.yml b/molecule/newdep/molecule.yml
index a7fe6f3..a347148 100644
--- a/molecule/newdep/molecule.yml
+++ b/molecule/newdep/molecule.yml
@@ -1,4 +1,6 @@
 ---
+# TODO: Delete this test when 5.6 is released
+# (latest won't be supported on py2)
 dependency:
   name: galaxy
   options:
diff --git a/molecule/python3/molecule.yml b/molecule/python3/molecule.yml
index 0af8b98..a0b0055 100644
--- a/molecule/python3/molecule.yml
+++ b/molecule/python3/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     privileged: true
     groups:
       - docker-hosts
+      - omero-py3
 provisioner:
   name: ansible
   lint:
@@ -28,20 +29,11 @@ provisioner:
     # tags: [x]
   playbooks:
     # TODO: Use shared test playbooks
-    converge: playbook.yml
-    # converge: ../resources/upgrade-omero.yml
+    converge: ../resources/playbook-py3.yml
   inventory:
     host_vars:
       omero-server-python3:
-        omero_server_python_addons:
-          - omero-upload
-        omero_server_python3: true
         postgresql_version: "10"
-        omero_server_release: 5.6.0-m3
-        # These used to be set in meta/main.yml but it doesn't work
-        ice_install_devel: false
-        ice_install_python: false
-
     group_vars:
       docker-hosts:
         omero_server_systemd_require_network: false
diff --git a/molecule/python3/playbook.yml b/molecule/resources/playbook-py3.yml
similarity index 90%
rename from molecule/python3/playbook.yml
rename to molecule/resources/playbook-py3.yml
index 855d6df..214eef3 100644
--- a/molecule/python3/playbook.yml
+++ b/molecule/resources/playbook-py3.yml
@@ -23,6 +23,10 @@
           - plate
           - project
           - dataset
+      omero_server_python3: true
+      omero_server_release: 5.6.0-m4
+      omero_server_python_addons:
+        - omero-upload
 
   tasks:
 
diff --git a/molecule/resources/tests/test_import.py b/molecule/resources/tests/test_import.py
index ad7cc10..b9aa2ca 100644
--- a/molecule/resources/tests/test_import.py
+++ b/molecule/resources/tests/test_import.py
@@ -3,7 +3,7 @@ import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts(
-        'omero-server-newdep,omero-server-python3,omero-server-upgradetovenv')
+        'omero-server-newdep,omero-server-upgradetovenv,omero-py3')
 
 OMERO = '/opt/omero/server/OMERO.server/bin/omero'
 OMERO_LOGIN = '-C -s localhost -u root -w omero'
diff --git a/molecule/resources/tests/test_python3.py b/molecule/resources/tests/test_python3.py
index ec512bb..0463716 100644
--- a/molecule/resources/tests/test_python3.py
+++ b/molecule/resources/tests/test_python3.py
@@ -3,8 +3,7 @@ import re
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts(
-        'omero-server-python3')
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('omero-py3')
 
 OMERO = '/opt/omero/server/OMERO.server/bin/omero'
 # Need to match 5.6.dev2
diff --git a/molecule/upgrade-py2py3/Dockerfile.j2 b/molecule/upgrade-py2py3/Dockerfile.j2
new file mode 120000
index 0000000..0e9184b
--- /dev/null
+++ b/molecule/upgrade-py2py3/Dockerfile.j2
@@ -0,0 +1 @@
+../resources/Dockerfile.j2
\ No newline at end of file
diff --git a/molecule/upgrade-py2py3/molecule.yml b/molecule/upgrade-py2py3/molecule.yml
new file mode 100644
index 0000000..c56fa17
--- /dev/null
+++ b/molecule/upgrade-py2py3/molecule.yml
@@ -0,0 +1,47 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: molecule/resources/requirements.yml
+driver:
+  name: docker
+lint:
+  name: yamllint
+platforms:
+  - name: omero-server-py2py3
+    image: centos/systemd
+    image_version: latest
+    command: /sbin/init
+    privileged: true
+    groups:
+      - docker-hosts
+      - omero-py3
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+  options:
+    v: true
+    diff: true
+    # tags: [x]
+  playbooks:
+    # TODO: Use shared test playbooks
+    prepare: ../resources/install-oldomero.yml
+    converge: ../resources/playbook-py3.yml
+  inventory:
+    host_vars:
+      omero-server-py2py3:
+        postgresql_version: "10"
+    group_vars:
+      docker-hosts:
+        omero_server_systemd_require_network: false
+scenario:
+  name: upgrade-py2py3
+  converge_sequence:
+    - converge
+
+verifier:
+  name: testinfra
+  directory: ../resources/tests/
+  lint:
+    name: flake8
diff --git a/tasks/omero-configfiles.yml b/tasks/omero-configfiles.yml
index ad3ca29..f8ec0ee 100644
--- a/tasks/omero-configfiles.yml
+++ b/tasks/omero-configfiles.yml
@@ -8,10 +8,18 @@
     force: true
     src: omero-server-config-update-sh.j2
     mode: 0555
+  when: not omero_server_python3
   notify:
     - omero-server rewrite omero-server configuration
     - omero-server restart omero-server
 
+- name: omero server | remove old configuration script
+  become: true
+  file:
+    path: "{{ omero_server_basedir }}/config/omero-server-config-update.sh"
+    state: absent
+  when: omero_server_python3
+
 - name: omero server | configuration 00-omero-server.omero
   become: true
   template:
diff --git a/tasks/omero-install.yml b/tasks/omero-install.yml
index 8270b90..db2d096 100644
--- a/tasks/omero-install.yml
+++ b/tasks/omero-install.yml
@@ -91,7 +91,7 @@
             (
               (omero_server_version | default('') | length > 0) and
               (omero_server_version != _omero_server_new_version) and
-              (omero_server_version is version_compare(
+              (omero_server_version is version(
                 _omero_server_new_version,
                 omero_server_checkupgrade_comparator))
             )
diff --git a/templates/systemd-system-omero-server-service.j2 b/templates/systemd-system-omero-server-service.j2
index 30fbed4..70526ee 100644
--- a/templates/systemd-system-omero-server-service.j2
+++ b/templates/systemd-system-omero-server-service.j2
@@ -29,7 +29,7 @@ TimeoutSec=300
 {% if omero_server_virtualenv and not omero_server_python3 %}
 Environment="PATH={{ omero_server_basedir }}/venv/bin:/bin:/usr/bin"
 {% endif %}
-ExecStartPre={{ omero_server_basedir }}/config/omero-server-config-update.sh
+ExecStartPre={{ omero_server_config_update }}
 ExecStart={{ omero_server_omero_command }} admin start
 ExecStop={{ omero_server_omero_command }} admin stop
 {% if omero_server_systemd_limit_nofile %}
```