### PR TITLE
Add infrastructure for a server extras image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ ADD playbook.yml requirements.yml /opt/setup/
 
 RUN yum -y install epel-release \
     && yum -y install ansible sudo \
-    && ansible-galaxy install -p /opt/setup/roles -r requirements.yml
+    && ansible-galaxy install -p /opt/setup/roles -r requirements.yml \
+    && yum clean all
 
 ARG OMERO_VERSION=5.6.1
 ARG OMEGO_ADDITIONAL_ARGS=

--- a/Makefile
+++ b/Makefile
@@ -65,13 +65,20 @@ endif
 ifndef BUILD
 	$(eval BUILD=0)
 endif
-	docker build -t $(REPO)/omero-server:$(VERSION)-$(BUILD) .
+	docker build $(BUILDARGS) -t $(REPO)/omero-server:$(VERSION)-$(BUILD) .
 	docker tag $(REPO)/omero-server:$(VERSION)-$(BUILD) $(REPO)/omero-server:$(VERSION)
 	@MAJOR_MINOR=$(shell echo $(VERSION) | cut -f1-2 -d. );\
 	docker tag $(REPO)/omero-server:$(VERSION)-$(BUILD) $(REPO)/omero-server:$$MAJOR_MINOR
 
+	docker build --build-arg=PARENT_IMAGE=$(REPO)/omero-server:$(VERSION) -t $(REPO)/omero-server-extras:$(VERSION)-$(BUILD) extras
+	docker tag $(REPO)/omero-server-extras:$(VERSION)-$(BUILD) $(REPO)/omero-server-extras:$(VERSION)
+	@MAJOR_MINOR=$(shell echo $(VERSION) | cut -f1-2 -d. );\
+	docker tag $(REPO)/omero-server-extras:$(VERSION)-$(BUILD) $(REPO)/omero-server-extras:$$MAJOR_MINOR
+
+
 docker-build: docker-build-versions
 	docker tag $(REPO)/omero-server:$(VERSION)-$(BUILD) $(REPO)/omero-server:latest
+	docker tag $(REPO)/omero-server-standalone:$(VERSION)-$(BUILD) $(REPO)/omero-server-extras:latest
 
 
 docker-push-versions:
@@ -86,5 +93,11 @@ endif
 	@MAJOR_MINOR=$(shell echo $(VERSION) | cut -f1-2 -d. );\
 	docker push $(REPO)/omero-server:$$MAJOR_MINOR
 
+	docker push $(REPO)/omero-server-extras:$(VERSION)-$(BUILD)
+	docker push $(REPO)/omero-server-extras:$(VERSION)
+	@MAJOR_MINOR=$(shell echo $(VERSION) | cut -f1-2 -d. );\
+	docker push $(REPO)/omero-server-extras:$$MAJOR_MINOR
+
 docker-push: docker-push-versions
 	docker push $(REPO)/omero-server:latest
+	docker push $(REPO)/omero-server-extras:latest

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ endif
 
 docker-build: docker-build-versions
 	docker tag $(REPO)/omero-server:$(VERSION)-$(BUILD) $(REPO)/omero-server:latest
-	docker tag $(REPO)/omero-server-standalone:$(VERSION)-$(BUILD) $(REPO)/omero-server-extras:latest
+	docker tag $(REPO)/omero-server-extras:$(VERSION)-$(BUILD) $(REPO)/omero-server-extras:latest
 
 
 docker-push-versions:

--- a/extras/01-default-extras.omero
+++ b/extras/01-default-extras.omero
@@ -1,0 +1,1 @@
+# OMERO.server extras

--- a/extras/Dockerfile
+++ b/extras/Dockerfile
@@ -1,0 +1,9 @@
+ARG PARENT_IMAGE=openmicroscopy/omero-server:latest
+FROM ${PARENT_IMAGE}
+MAINTAINER ome-devel@lists.openmicroscopy.org.uk
+
+USER root
+
+ADD 01-default-extras.omero /opt/omero/server/config/
+
+USER omero-server

--- a/extras/Dockerfile
+++ b/extras/Dockerfile
@@ -4,6 +4,10 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 USER root
 
+RUN yum -y install \
+    git \
+    && yum clean all
+
 ADD 01-default-extras.omero /opt/omero/server/config/
 
 USER omero-server


### PR DESCRIPTION
This is based on the standalone image from https://github.com/ome/omero-web-docker/tree/5.6.0-m4
This just provides the infrastructure for building the extras image, it doesn't install or change anything (see https://github.com/ome/omero-server-docker/pull/21 instead for something that would use it)

--exclude