### PR TITLE
Remove bin/omero

### DIFF
--- a/50-config.py
+++ b/50-config.py
@@ -10,7 +10,7 @@ from re import sub
 
 
 CONFIG_OMERO = '/opt/omero/server/config/omero-server-config-update.sh'
-OMERO = '/opt/omero/server/OMERO.server/bin/omero'
+OMERO = '/opt/omero/server/venv3/bin/omero'
 
 if os.access(CONFIG_OMERO, os.X_OK):
     rc = call([CONFIG_OMERO])

--- a/60-database.sh
+++ b/60-database.sh
@@ -5,7 +5,7 @@
 
 set -eu
 
-omero=/opt/omero/server/OMERO.server/bin/omero
+omero=/opt/omero/server/venv3/bin/omero
 omego=/opt/omero/server/venv3/bin/omego
 cd /opt/omero/server
 

--- a/99-run.sh
+++ b/99-run.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-omero=/opt/omero/server/OMERO.server/bin/omero
+omero=/opt/omero/server/venv3/bin/omero
 cd /opt/omero/server
 echo "Starting OMERO.server"
 exec $omero admin start --foreground

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN yum -y install epel-release \
     && yum -y install ansible sudo git \
     && ansible-galaxy install -p /opt/setup/roles -r requirements.yml
 
-ARG OMERO_VERSION=5.6.0-m4
+ARG OMERO_VERSION=5.6.0-m5
 ARG OMEGO_ADDITIONAL_ARGS=
 ENV OMERODIR=/opt/omero/server/OMERO.server/
 RUN ansible-playbook playbook.yml \

--- a/test_dropbox.sh
+++ b/test_dropbox.sh
@@ -7,7 +7,7 @@ set -x
 # Must be exported by the caller:
 # OMERO_USER OMERO_PASS PREFIX
 
-OMERO=/opt/omero/server/OMERO.server/bin/omero
+OMERO=/opt/omero/server/venv3/bin/omero
 FILENAME=$(date +%Y%m%d-%H%M%S-%N).fake
 SERVER=localhost:4064
 docker exec $PREFIX-server sh -c \

--- a/test_login.sh
+++ b/test_login.sh
@@ -7,7 +7,7 @@ set -x
 # Must be exported by the caller:
 # OMERO_USER OMERO_PASS PREFIX
 
-OMERO=/opt/omero/server/OMERO.server/bin/omero
+OMERO=/opt/omero/server/venv3/bin/omero
 SERVER="localhost:4064"
 
 # Wait up to 2 mins

--- a/test_processor.sh
+++ b/test_processor.sh
@@ -7,7 +7,7 @@ set -x
 # Must be exported by the caller:
 # OMERO_USER OMERO_PASS PREFIX
 
-OMERO=/opt/omero/server/OMERO.server/bin/omero
+OMERO=/opt/omero/server/venv3/bin/omero
 DSNAME=$(date +%Y%m%d-%H%M%S-%N)
 FILENAME=$(date +%Y%m%d-%H%M%S-%N).fake
 SCRIPT=/omero/util_scripts/Dataset_To_Plate.py


### PR DESCRIPTION
All references to the `omero` executable should be done under `venv3`.

See: https://github.com/ome/openmicroscopy/pull/6200