### PR TITLE
Bump to 5.6.0-rc1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN yum -y install epel-release \
     && yum -y install ansible sudo git \
     && ansible-galaxy install -p /opt/setup/roles -r requirements.yml
 
-ARG OMERO_VERSION=5.6.0-m5
+ARG OMERO_VERSION=5.6.0-rc1
 ARG OMEGO_ADDITIONAL_ARGS=
 ENV OMERODIR=/opt/omero/server/OMERO.server/
 RUN ansible-playbook playbook.yml \

--- a/playbook.yml
+++ b/playbook.yml
@@ -8,3 +8,4 @@
     omero_server_system_uid: 1000
     omero_server_virtualenv: True
     omero_server_python3: True
+    omero_server_python3_replace_omero: False

--- a/requirements.yml
+++ b/requirements.yml
@@ -13,8 +13,8 @@
   version: 0.3.2
 
 - name: ome.omero_server
-  src: https://github.com/ome/ansible-role-omero-server/archive/19747f05bba640df9f562fd95b1cae655ebe8e0c.tar.gz
-  version: 19747f05bba640df9f562fd95b1cae655ebe8e0c
+  src: https://github.com/joshmoore/ansible-role-omero-server/archive/94f406d552139f732d3463b223efc8e209f5024a.tar.gz
+  version: 94f406d552139f732d3463b223efc8e209f5024a
 
 - src: ome.postgresql
   version: 3.3.1

--- a/requirements.yml
+++ b/requirements.yml
@@ -13,8 +13,8 @@
   version: 0.3.2
 
 - name: ome.omero_server
-  src: https://github.com/joshmoore/ansible-role-omero-server/archive/94f406d552139f732d3463b223efc8e209f5024a.tar.gz
-  version: 94f406d552139f732d3463b223efc8e209f5024a
+  src: https://github.com/ome/ansible-role-omero-server/archive/6617b30a270dc1ca53d8ce1818fb8cbf1857ad3a.tar.gz
+  version: 6617b30a270dc1ca53d8ce1818fb8cbf1857ad3a
 
 - src: ome.postgresql
   version: 3.3.1


### PR DESCRIPTION
Includes the removal of bin/omero and lib/python from https://github.com/ome/openmicroscopy/pull/6200