### PR TITLE
Consume development ome.ice role without Java dependency

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,8 +3,7 @@
 - src: ome.basedeps
   version: 1.1.0
 
-- name: ome.ice
-  src: https://github.com/ome/ansible-role-ice/archive/efe4e218fe25d39c6e0bdb89570b7cf2d3f799a8.tar.gz
+- src: ome.ice
   version: 4.1.0
 
 - src: ome.java

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,8 +3,9 @@
 - src: ome.basedeps
   version: 1.1.0
 
-- src: ome.ice
-  version: 4.0.0
+- name: ome.ice
+  src: https://github.com/ome/ansible-role-ice/archive/efe4e218fe25d39c6e0bdb89570b7cf2d3f799a8.tar.gz
+  version: 4.1.0
 
 - src: ome.java
   version: 2.1.0


### PR DESCRIPTION
Fixes #45  and depends on https://github.com/ome/ansible-role-ice/pull/14/

With this change, the Java version of the omero-server Docker image should be 11 (as installed by the playbook) rather then 8 pulled by the `ice-runtime` meta-package. 