### PR TITLE
Fix and test config mounts

### DIFF
--- a/50-config.py
+++ b/50-config.py
@@ -9,12 +9,10 @@ from subprocess import call
 from re import sub
 
 
-CONFIG_OMERO = '/opt/omero/server/config/omero-server-config-update.sh'
 OMERO = '/opt/omero/server/venv3/bin/omero'
 
-if os.access(CONFIG_OMERO, os.X_OK):
-    rc = call([CONFIG_OMERO])
-    assert rc == 0
+rc = call([OMERO, 'load', '--glob', '/opt/omero/server/config/*.omero'])
+assert rc == 0
 
 for (k, v) in os.environ.items():
     if k.startswith('CONFIG_'):

--- a/test-config/config.omero
+++ b/test-config/config.omero
@@ -1,0 +1,1 @@
+config set custom.property.fromfile fromfile

--- a/test.sh
+++ b/test.sh
@@ -22,12 +22,16 @@ cleanup || true
 
 docker build -t $IMAGE  .
 docker run -d --name $PREFIX-db -e POSTGRES_PASSWORD=postgres postgres:10
+
+# Check both CONFIG_environment and *.omero config mounts work
 docker run -d --name $PREFIX-server --link $PREFIX-db:db \
     -p 4064 \
     -e CONFIG_omero_db_user=postgres \
     -e CONFIG_omero_db_pass=postgres \
     -e CONFIG_omero_db_name=postgres \
+    -e CONFIG_custom_property_fromenv=fromenv \
     -e ROOTPASS=omero-root-password \
+    -v $PWD/test-config/config.omero:/opt/omero/server/config/config.omero:ro \
     $IMAGE
 
 # Smoke tests
@@ -38,6 +42,10 @@ export PREFIX
 
 # Login to server
 bash test_login.sh
+
+# Check the Docker OMERO configuration system
+bash test_config.sh
+
 # Wait a minute to ensure other servers are running
 sleep 60
 # Now that we know the server is up, test Dropbox

--- a/test_config.sh
+++ b/test_config.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+set -u
+set -x
+
+# Must be exported by the caller:
+# PREFIX
+
+OMERO=/opt/omero/server/venv3/bin/omero
+
+docker exec $PREFIX-server $OMERO config get --show-password
+
+[[ $(docker exec $PREFIX-server $OMERO config get custom.property.fromenv) = "fromenv" ]]
+[[ $(docker exec $PREFIX-server $OMERO config get custom.property.fromfile) = "fromfile" ]]


### PR DESCRIPTION
`omero-server-config-update.sh` was replaced by `omero load --glob /opt/omero/server/config/*.omero` in OMERO.py 5.6 (Python 3)

The Ansible role systemd service was switched to use the new built-in `load --glob` feature in OMERO.py but this Docker image wasn't updated to match.