### PR TITLE
Enable omero-certificates

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -4,6 +4,7 @@
   vars:
     java_versions: ["11"]
     omero_server_database_manage: False
+    omero_server_selfsigned_certificates: True
     omero_server_systemd_setup: False
     omero_server_system_uid: 1000
     omero_server_virtualenv: True

--- a/requirements.yml
+++ b/requirements.yml
@@ -13,7 +13,7 @@
   version: 0.3.2
 
 - name: ome.omero_server
-  version: 3.0.0
+  version: 3.3.0
 
-- name: ome.postgresql
-  version: 4.0.0
+- name: ome.postgresql_client
+  version: 0.1.2

--- a/test_config.sh
+++ b/test_config.sh
@@ -13,3 +13,7 @@ docker exec $PREFIX-server $OMERO config get --show-password
 
 [[ $(docker exec $PREFIX-server $OMERO config get custom.property.fromenv) = "fromenv" ]]
 [[ $(docker exec $PREFIX-server $OMERO config get custom.property.fromfile) = "fromfile" ]]
+
+# Check whether the certificates plugin worked, AES256-SHA is not enabled by
+# default so this command will fail if the certificates plugin failed
+docker exec test-server openssl s_client -cipher AES256-SHA -connect localhost:4064


### PR DESCRIPTION
Enables omero-certificates (https://github.com/ome/ansible-role-omero-server/pull/50)
See https://forum.image.sc/t/trouble-connecting-to-omero-server-with-python/46097/10 , I can't see any harm in enabling it by default.

Requires this bug fix to the config system: https://github.com/ome/omero-server-docker/pull/47