### PR TITLE
Fix Docker build with latest OpenJDK releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN yum -y install epel-release \
     && yum -y install ansible sudo \
     && ansible-galaxy install -p /opt/setup/roles -r requirements.yml
 
-ARG OMERO_VERSION=5.6.1
+ARG OMERO_VERSION=5.6.3
 ARG OMEGO_ADDITIONAL_ARGS=
 ENV OMERODIR=/opt/omero/server/OMERO.server/
 RUN ansible-playbook playbook.yml \

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,19 +1,19 @@
 # External Ansible roles required by this repository
 
 - src: ome.basedeps
-  version: 1.1.0
+  version: 1.2.0
 
 - src: ome.ice
-  version: 4.1.0
+  version: 4.3.0
 
 - src: ome.java
   version: 2.1.0
 
 - src: ome.omero_common
-  version: 0.3.2
+  version: 0.3.4
 
 - name: ome.omero_server
-  version: 3.3.0
+  version: 4.0.1
 
 - name: ome.postgresql_client
   version: 0.1.2

--- a/test_login.sh
+++ b/test_login.sh
@@ -11,14 +11,5 @@ OMERO=/opt/omero/server/venv3/bin/omero
 SERVER="localhost:4064"
 
 # Wait up to 2 mins
-i=0
-while ! docker exec $PREFIX-server $OMERO login -C -s $SERVER -u "$OMERO_USER" -q -w "$OMERO_PASS"; do
-    i=$(($i+1))
-    if [ $i -ge 24 ]; then
-        echo "$(date) - OMERO.server still not reachable, giving up"
-        exit 1
-    fi
-    echo "$(date) - waiting for OMERO.server..."
-    sleep 5
-done
+docker exec $PREFIX-server $OMERO login -C -s $SERVER -u "$OMERO_USER" -q -w "$OMERO_PASS" --retry 120
 echo "OMERO.server connection established"

--- a/test_processor.sh
+++ b/test_processor.sh
@@ -15,10 +15,8 @@ SERVER="localhost:4064"
 
 dataset_id=$(docker exec $PREFIX-server $OMERO obj -q -s $SERVER -u $OMERO_USER -w $OMERO_PASS new Dataset name=$DSNAME | cut -d: -f2)
 
-# Fixed in 5.5.0 https://github.com/openmicroscopy/openmicroscopy/pull/5949
-BUGFIX_ARGS="--skip upgrade"
 docker exec $PREFIX-server sh -c \
-    "touch /tmp/$FILENAME && $OMERO import $BUGFIX_ARGS -d $dataset_id /tmp/$FILENAME"
+    "touch /tmp/$FILENAME && $OMERO import -d $dataset_id /tmp/$FILENAME"
 
 docker exec $PREFIX-server $OMERO script launch $SCRIPT IDs=$dataset_id
 echo "Completed with code $?"


### PR DESCRIPTION
See https://github.com/ome/ansible-role-omero-server/issues/57

This PR:

- bump the Ansible roles to their latest releases
- bumps `OMERO_VERSION` to 5.6.3
- updates `test_login.sh` the new `omero login --retry` API 