### PR TITLE
Also set the Docker namespace on tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,13 +19,13 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     env:
-      name: omero-server
+      name: openmicroscopy/omero-server
     steps:
       - name: Get prefix
         id: getprefix
         run: |
           if [ ! -z ${{ env.name }} ]; then
-            echo "::set-output name=prefix::${{ github.actor }}/${{ env.name }}:"
+            echo "::set-output name=prefix::${{ env.name }}:"
           else
             echo "::set-output name=prefix::${{ github.repository }}:"
           fi


### PR DESCRIPTION
Follow-up of https://github.com/ome/omero-server-docker/pull/51, after setting up the organization secrets, the build following a tag failed with https://github.com/ome/omero-server-docker/runs/2457329377?check_suite_focus=true. In particular

```
Run docker/build-push-action@v2
  with:
    tags: sbesson/omero-server:5.6.3-2,sbesson/omero-server:5.6.3,sbesson/omero-server:5.6,sbesson/omero-server:5,sbesson/omero-server:latest
    push: true
    load: false
    no-cache: false
    pull: false
    github-token: ***
```