### PR TITLE
Docker dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos7
+FROM centos:centos7.9.2009
 LABEL maintainer="ome-devel@lists.openmicroscopy.org.uk"
 LABEL org.opencontainers.image.created="unknown"
 LABEL org.opencontainers.image.revision="unknown"


### PR DESCRIPTION
It's unclear what the frequency of overwrites of existing tags on Docker Hub are. If they occur frequently, then this PR should get us equally frequent rebuilds of our base image.

See https://github.com/dependabot/feedback/issues/129 for background.