### PR TITLE
install figure export dependencies by default

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -1,6 +1,9 @@
 - hosts: localhost
   roles:
   - role: ome.omero_server
+    omero_server_python_addons:
+        - "reportlab<3.6"
+        - markdown
   vars:
     java_versions: ["11"]
     omero_server_database_manage: False

--- a/playbook.yml
+++ b/playbook.yml
@@ -2,7 +2,7 @@
   roles:
   - role: ome.omero_server
     omero_server_python_addons:
-        - "reportlab<3.6"
+        - reportlab
         - markdown
   vars:
     java_versions: ["11"]


### PR DESCRIPTION
Install dependencies required to export figure
Figure might not be installed  but this should avoid error like https://github.com/ome/docker-example-omero/issues/11