### PR TITLE
use ubuntu 20.04 as base instead of CentOS7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos7.9.2009@sha256:dead07b4d8ed7e29e98de0f4504d87e8880d4347859d839686a31da35a3b532f
+FROM ubuntu:20.04
 LABEL maintainer="ome-devel@lists.openmicroscopy.org.uk"
 LABEL org.opencontainers.image.created="unknown"
 LABEL org.opencontainers.image.revision="unknown"
@@ -8,29 +8,32 @@ RUN mkdir /opt/setup
 WORKDIR /opt/setup
 ADD playbook.yml requirements.yml /opt/setup/
 
-RUN yum -y install epel-release \
-    && yum -y install ansible sudo ca-certificates \
+RUN apt update
+RUN apt install -y ansible sudo ca-certificates dumb-init\
     && ansible-galaxy install -p /opt/setup/roles -r requirements.yml \
-    && yum -y clean all \
-    && rm -fr /var/cache
+    && apt -y autoclean \
+    && apt -y autoremove
+
 
 ARG OMERO_VERSION=5.6.5
 ARG OMEGO_ADDITIONAL_ARGS=
 ENV OMERODIR=/opt/omero/server/OMERO.server/
+
 RUN ansible-playbook playbook.yml \
     -e omero_server_release=$OMERO_VERSION \
     -e omero_server_omego_additional_args="$OMEGO_ADDITIONAL_ARGS" \
-    && yum -y clean all \
+    && apt -y autoclean \
+    && apt -y autoremove \
     && rm -fr /var/cache
 
-RUN curl -L -o /usr/local/bin/dumb-init \
-    https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 && \
-    chmod +x /usr/local/bin/dumb-init
+
 ADD entrypoint.sh /usr/local/bin/
 ADD 50-config.py 60-database.sh 99-run.sh /startup/
 
 USER omero-server
 EXPOSE 4063 4064
+ENV PATH=$PATH:/opt/ice/bin
+
 VOLUME ["/OMERO", "/opt/omero/server/OMERO.server/var"]
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ LABEL org.opencontainers.image.created="unknown"
 LABEL org.opencontainers.image.revision="unknown"
 LABEL org.opencontainers.image.source="https://github.com/openmicroscopy/omero-server-docker"
 
+ENV DEBIAN_FRONTEND=noninteractive
+
+
 RUN mkdir /opt/setup
 WORKDIR /opt/setup
 ADD playbook.yml requirements.yml /opt/setup/
@@ -12,7 +15,8 @@ RUN apt update
 RUN apt install -y ansible sudo ca-certificates dumb-init\
     && ansible-galaxy install -p /opt/setup/roles -r requirements.yml \
     && apt -y autoclean \
-    && apt -y autoremove
+    && apt -y autoremove \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
 
 
 ARG OMERO_VERSION=5.6.5
@@ -24,7 +28,7 @@ RUN ansible-playbook playbook.yml \
     -e omero_server_omego_additional_args="$OMEGO_ADDITIONAL_ARGS" \
     && apt -y autoclean \
     && apt -y autoremove \
-    && rm -fr /var/cache
+    && rm -rf /var/lib/apt/lists/* /tmp/*
 
 
 ADD entrypoint.sh /usr/local/bin/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/local/bin/dumb-init /bin/bash
+#!/usr/bin/dumb-init /bin/bash
 
 set -e
 source /opt/omero/server/venv3/bin/activate


### PR DESCRIPTION
Following this discussion: https://github.com/ome/omero-web-docker/issues/67 (it's on the web image, sorry) I ported the DockerFile to ubuntu, which is quite painless thanks to ansible being already aware of ubuntu 20.04

questions:
- [ ] how to add sha256 information in the `FROM` line (not sure where that info is)
- [ ] understand why the PATH is changed here and not on the playbooks
- [ ] maybe trim the image a bit more?