### PR TITLE
Set locale to en_US.utf-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ LABEL org.opencontainers.image.created="unknown"
 LABEL org.opencontainers.image.revision="unknown"
 LABEL org.opencontainers.image.source="https://github.com/openmicroscopy/omero-server-docker"
 
+ENV LANG en_US.utf-8
+
 RUN mkdir /opt/setup
 WORKDIR /opt/setup
 ADD playbook.yml requirements.yml /opt/setup/


### PR DESCRIPTION
The current image has the locale set to `POSIX`, while OMERO.server expects to run in a `UTF8` locale. This changes the system locale to `en_US.utf-8` by setting the `LANG` environment variable. See [this thread](https://forum.image.sc/t/qupath-extension-biop-omero-cant-import-images-after-successful-login/76003/13?u=michele_bortolomeazz) on the image.sc forum for reference: 