### PR TITLE
Build rocky9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,36 @@
-FROM centos:centos7.9.2009@sha256:dead07b4d8ed7e29e98de0f4504d87e8880d4347859d839686a31da35a3b532f
+FROM ubuntu:22.04
 LABEL maintainer="ome-devel@lists.openmicroscopy.org.uk"
 
 ENV LANG en_US.utf-8
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN mkdir /opt/setup
 WORKDIR /opt/setup
 ADD playbook.yml requirements.yml /opt/setup/
 
-RUN yum -y install epel-release \
-    && yum -y install ansible sudo ca-certificates \
+RUN apt update\
+    && apt install -y ansible sudo ca-certificates dumb-init \
     && ansible-galaxy install -p /opt/setup/roles -r requirements.yml \
-    && yum -y clean all \
-    && rm -fr /var/cache
+    && apt -y autoclean autoremove \
+    && rm -fr /var/lib/apt/lists/* /tmp/*
 
-ARG OMERO_VERSION=5.6.8
+ARG OMERO_VERSION=5.6.9
 ARG OMEGO_ADDITIONAL_ARGS=
 ENV OMERODIR=/opt/omero/server/OMERO.server/
+
 RUN ansible-playbook playbook.yml \
     -e omero_server_release=$OMERO_VERSION \
     -e omero_server_omego_additional_args="$OMEGO_ADDITIONAL_ARGS" \
-    && yum -y clean all \
-    && rm -fr /var/cache
+    && apt -y autoclean autoremove \
+    && rm -fr /var/lib/apt/lists/* /tmp/*
 
-RUN curl -L -o /usr/local/bin/dumb-init \
-    https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 && \
-    chmod +x /usr/local/bin/dumb-init
 ADD entrypoint.sh /usr/local/bin/
 ADD 50-config.py 60-database.sh 99-run.sh /startup/
 
 USER omero-server
 EXPOSE 4063 4064
+ENV PATH=$PATH:/opt/ice/bin
+
 VOLUME ["/OMERO", "/opt/omero/server/OMERO.server/var"]
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/dumb-init /bin/bash
+#!/usr/local/bin/dumb-init /bin/bash
 
 set -e
 source /opt/omero/server/venv3/bin/activate

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/local/bin/dumb-init /bin/bash
+#!/usr/bin/dumb-init /bin/bash
 
 set -e
 source /opt/omero/server/venv3/bin/activate

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,6 +1,6 @@
 - hosts: localhost
   roles:
-  - role: ome.omero_server
+  - role: khaledk2.omero_server
   vars:
     java_versions: ["11"]
     omero_server_database_manage: False

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,19 +1,3 @@
 # External Ansible roles required by this repository
-
-- name: ome.basedeps
-  version: 1.2.0
-
-- name: ome.ice
-  version: 4.3.0
-
-- name: ome.java
-  version: 2.1.0
-
-- name: ome.omero_common
-  version: 0.3.4
-
 - name: ome.omero_server
-  version: 4.0.2
 
-- name: ome.postgresql_client
-  version: 0.1.2

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,2 @@
 # External Ansible roles required by this repository
-- name: ome.omero_server
-
+- name: khaledk2.omero_server

--- a/test.sh
+++ b/test.sh
@@ -21,7 +21,7 @@ cleanup || true
 
 
 docker build -t $IMAGE  .
-docker run -d --name $PREFIX-db -e POSTGRES_PASSWORD=postgres postgres:10
+docker run -d --name $PREFIX-db -e POSTGRES_PASSWORD=postgres postgres:14
 
 # Check both CONFIG_environment and *.omero config mounts work
 docker run -d --name $PREFIX-server --link $PREFIX-db:db \


### PR DESCRIPTION
This PR contains the required modifications to build `Omero server` Docker image.
It uses `khaledk2.omero_server` ansible role. Once https://github.com/ome/ansible-role-omero-server/pull/71 is approved and the role is released, I will update it to use `ome.omero_server`.