### PR TITLE
bump actions/checkout 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Test
         run: ./test.sh
   upload:


### PR DESCRIPTION
bump actions/checkout to v4 to avoid node12 warning