### PR TITLE
Build  an ARM docker image for the OMERO server

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,4 @@
-#!/usr/local/bin/dumb-init /bin/bash
-
+#!/usr/bin/dumb-init /bin/bash
 set -e
 source /opt/omero/server/venv3/bin/activate
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,2 +1,4 @@
 # External Ansible roles required by this repository
 - name: ome.omero_server
+  src: https://github.com/khaledk2/ansible-role-omero-server/
+  version: aarch64_josh


### PR DESCRIPTION
I have used this PR to build an aarch64 image for the Omero server. It used the following ansible role:

- ome.omero_server
  - https://github.com/khaledk2/ansible-role-omero-server/
  - branch: aarch64_josh 

The  modified ome.omero_server ansible role uses the following modified two roles

- ansible-role-ice
  - https://github.com/khaledk2/ansible-role-ice
  - branch: arch64

- ome.postgresql_client
  - https://github.com/khaledk2/ansible-role-postgresql-client
  - branch : test_arch_import_key

The last one is the one which has been merged into the Ome master

In addition, I have built an ice package and wheel locally and pushed them to a dummy repo release to download them at run time

The built image has been pushed to:
khaledk2/omero-server:arm

cc @joshmoore @jburel @sbesson @pwalczysko 

