### PR TITLE
WiP Blosc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,6 @@ RUN ansible-playbook playbook.yml -vvv -e 'ansible_python_interpreter=/usr/bin/p
 RUN dnf -y clean all
 RUN rm -fr /var/cache
 
-
-RUN dnf install -y https://dl.rockylinux.org/pub/rocky/9/BaseOS/aarch64/os/Packages/b/bzip2-libs-1.0.8-8.el9.aarch64.rpm
-RUN ln -s  /usr/lib64/libbz2.so.1.0.8  /usr/lib64/libbz2.so.1.0
-
-
 WORKDIR /opt
 
 RUN source  omero/server/venv3/bin/activate

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir /opt/setup
 WORKDIR /opt/setup
 ADD playbook.yml requirements.yml /opt/setup/
 
-RUN dnf install -y ansible-core sudo ca-certificates
+RUN dnf install -y ansible-core sudo ca-certificates blosc
 RUN ansible-galaxy install -p /opt/setup/roles -r requirements.yml
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,4 @@
-#!/usr/local/bin/dumb-init /bin/bash
-
+#!/usr/bin/dumb-init /bin/bash
 set -e
 source /opt/omero/server/venv3/bin/activate
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,2 +1,4 @@
 # External Ansible roles required by this repository
 - name: ome.omero_server
+  src: https://github.com/khaledk2/ansible-role-omero-server/
+  version: aarch64_josh


### PR DESCRIPTION
This is based on https://github.com/ome/omero-server-docker/pull/87#issuecomment-1899115305 - 

Rationale:

The import of ome.zarr files into OMERO based on https://github.com/ome/omero-server-docker/pull/87#issuecomment-1899115305 is not successful, as blosc is not installed and found.
See also https://github.com/ome/ZarrReader/issues/76#issuecomment-1906438806

Adding blosc install as per this PR is fixing the issue of ``stacktrace=java.lang.NoClassDefFoundError: Could not initialize class org.blosc.IBloscDll at com.bc.zarr.CompressorFactory$BloscCompressor.cbufferSizes(CompressorFactory.java:371`` but a new issue emerges 

```
2024-01-23 16:18:15,889 6364       [l.Client-0] ERROR     ome.formats.importer.cli.ErrorHandler - INTERNAL_EXCEPTION: /Users/pwalczysko/Work/18188.zarr/0/0/0
java.lang.RuntimeException: Failure response on import!
Category: ::omero::grid::ImportRequest
Name: import-request-failure
Parameters: {stacktrace=java.lang.IndexOutOfBoundsException
	at java.base/java.io.DataInputStream.readFully(DataInputStream.java:197)
	at com.bc.zarr.CompressorFactory$BloscCompressor.uncompress(CompressorFactory.java:342)
	at com.bc.zarr.chunk.ChunkReaderWriterImpl_Byte.read(ChunkReaderWriterImpl_Byte.java:50)
	at com.bc.zarr.ZarrArray.read(ZarrArray.java:278)
	at com.bc.zarr.ZarrArray.read(ZarrArray.java:255)
...
```

Several points to discuss:

1. should we maybe rather install blosc by default in the ansible-role-omero-server ?
2. Is the ``IndexOOBounds`` error above connected with my Rockylinux-9 docker on M1 Mac setup ? How to fix it ?

cc @khaledk2 @jburel 