### PR TITLE
install blosc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="ome-devel@lists.openmicroscopy.org.uk"
 RUN dnf -y install epel-release
 RUN dnf -y update
 RUN dnf install -y glibc-langpack-en
+RUN dnf install -y blosc
 
 ENV LANG en_US.utf-8
 ENV RHEL_FRONTEND=noninteractive


### PR DESCRIPTION
This PR installs blosc, required by ZarrReader
See https://github.com/ome/omero-web-docker/issues/77 for background