### PR TITLE
Fix warning LegacyKeyValueFormat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN dnf -y update
 RUN dnf install -y glibc-langpack-en
 RUN dnf install -y blosc
 
-ENV LANG en_US.utf-8
+ENV LANG=en_US.utf-8
 ENV RHEL_FRONTEND=noninteractive
 RUN mkdir /opt/setup
 WORKDIR /opt/setup


### PR DESCRIPTION
This commit fixes below warning.

```
- LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 9)
```

Reported by and tested with Docker version 27.5.0.