### PR TITLE
WiP: Test from master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ARG OMERO_VERSION=5.6.16
 ARG OMEGO_ADDITIONAL_ARGS=
 ENV OMERODIR=/opt/omero/server/OMERO.server
 
-RUN ansible-playbook playbook.yml -vvv -e 'ansible_python_interpreter=/usr/bin/python3'\
+RUN ansible-playbook playbook.yml -vvv \
     -e omero_server_release=$OMERO_VERSION \
     -e omero_server_omego_additional_args="$OMEGO_ADDITIONAL_ARGS"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ARG OMERO_VERSION=5.6.16
 ARG OMEGO_ADDITIONAL_ARGS=
 ENV OMERODIR=/opt/omero/server/OMERO.server
 
-RUN ansible-playbook playbook.yml -vvv -e 'ansible_python_interpreter=/usr/bin/python3.12'\
+RUN ansible-playbook playbook.yml -vvv \
     -e omero_server_release=$OMERO_VERSION \
     -e omero_server_omego_additional_args="$OMEGO_ADDITIONAL_ARGS"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ARG OMERO_VERSION=5.6.16
 ARG OMEGO_ADDITIONAL_ARGS=
 ENV OMERODIR=/opt/omero/server/OMERO.server
 
-RUN ansible-playbook playbook.yml -vvv \
+RUN ansible-playbook playbook.yml -vvv -e 'ansible_python_interpreter=/usr/bin/python3.12'\
     -e omero_server_release=$OMERO_VERSION \
     -e omero_server_omego_additional_args="$OMEGO_ADDITIONAL_ARGS"
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,34 @@
-# External Ansible roles required by this repository
-- name: ome.postgresql
-- name: ome.omero_server
+---
+
+- src: ome.omero_common
+  version: 0.4.0
+
+- src: ome.basedeps
+  version: 1.3.2
+
+- src: ome.java
+  version: 2.2.0
+
+- src: ome.python3_virtualenv
+  version: 0.2.0
+
+
+- src: ome.ice
+  version: 4.4.4
+
+- src: ome.postgresql
+  version: 5.4.0
+
+
+- src: ome.postgresql_client
+  version: 0.4.3
+
+- src: ome.deploy_archive
+  version: 0.2.0
+
+- src: ome.omero_server
+  version: 6.1.0
+
+
+- src: ome.ssl_certificate
+  version: 0.5.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,2 +1,3 @@
 # External Ansible roles required by this repository
+- name: ome.postgresql
 - name: ome.omero_server

--- a/test.sh
+++ b/test.sh
@@ -21,7 +21,7 @@ cleanup || true
 
 
 docker build -t $IMAGE  .
-docker run -d --name $PREFIX-db -e POSTGRES_PASSWORD=postgres postgres:14
+docker run -d --name $PREFIX-db -e POSTGRES_PASSWORD=postgres postgres:16
 
 # Check both CONFIG_environment and *.omero config mounts work
 docker run -d --name $PREFIX-server --link $PREFIX-db:db \

--- a/test.sh
+++ b/test.sh
@@ -30,14 +30,14 @@ docker run -d --name $PREFIX-server --link $PREFIX-db:db \
     -e CONFIG_omero_db_pass=postgres \
     -e CONFIG_omero_db_name=postgres \
     -e CONFIG_custom_property_fromenv=fromenv \
-    -e ROOTPASS=omero-root-password \
+    -e ROOTPASS=omero \
     -v $PWD/test-config/config.omero:/opt/omero/server/config/config.omero:ro \
     $IMAGE
 
 # Smoke tests
 
 export OMERO_USER=root
-export OMERO_PASS=omero-root-password
+export OMERO_PASS=omero
 export PREFIX
 
 # Login to server


### PR DESCRIPTION
After upgrade of the roles, the tests are red here now. 

Trying to find out why.

The error atm seems to be

```
...
No descriptor given. Using etc/grid/default.xml
5.21.2
Running /startup/99-run.sh 
Starting OMERO.server
test-db
test-server
Error response from daemon: No such container: test-server
```

It seems to me that the ``test-server`` container must exist, as there is a successful login from before. But the test import via DropBox most probably fails, because the ``hql`` query which should retrieve the imported image is coming empty.









Opening this although the tests are red - just to see the GHA log output here.