### PR TITLE
Fix the push step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,15 +32,15 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.name }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Push to Docker Hub
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v2
         with:
           tags: ${{ join(fromJson(steps.gettags.outputs.tags)) }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This is to fix the push step in the GHA which failed in last attempt, see https://github.com/ome/omero-server-docker/actions/runs/19666539583/job/56325443561


The fix was designed and tested by @jburel 


