### PR TITLE
Add Figure_To_Pdf script to Docker image and update workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ name: Build
 on: 
   push:
   pull_request:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * 0'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,11 @@ RUN ansible-playbook playbook.yml -vvv -e 'ansible_python_interpreter=/usr/bin/p
 RUN dnf -y clean all
 RUN rm -fr /var/cache
 
+ARG OMERO_FIGURE_VERSION=v7.4.1
+RUN mkdir -p $OMERODIR/lib/scripts/omero/figure_scripts && \
+    curl -fsSL -o $OMERODIR/lib/scripts/omero/figure_scripts/Figure_To_Pdf.py \
+    https://raw.githubusercontent.com/ome/omero-figure/$OMERO_FIGURE_VERSION/omero_figure/scripts/omero/figure_scripts/Figure_To_Pdf.py
+
 RUN curl -L -o /usr/local/bin/dumb-init \
     https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64 && \
     chmod +x /usr/local/bin/dumb-init

--- a/test.sh
+++ b/test.sh
@@ -54,3 +54,6 @@ bash test_dropbox.sh
 
 # And Processor (slave-1)
 bash test_processor.sh
+
+# Check Figure_To_Pdf.py script is available
+bash test_figure_script.sh

--- a/test_figure_script.sh
+++ b/test_figure_script.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+set -u
+set -x
+
+# Must be exported by the caller:
+# OMERO_USER OMERO_PASS PREFIX
+
+OMERO=/opt/omero/server/venv3/bin/omero
+SERVER="localhost:4064"
+
+script_list=$(docker exec $PREFIX-server $OMERO -s $SERVER -u $OMERO_USER -w $OMERO_PASS script list)
+echo "$script_list"
+
+if echo "$script_list" | grep -q "Figure_To_Pdf.py"; then
+    echo "Figure_To_Pdf.py found in script list"
+else
+    echo "Figure_To_Pdf.py NOT found in script list"
+    exit 2
+fi


### PR DESCRIPTION
This pull request introduces support for the `Figure_To_Pdf.py` script from the OMERO Figure project, ensuring it is included in the build and verified during testing. Additionally, it enables manual workflow dispatch in GitHub Actions. The main changes are grouped below:

**OMERO Figure script integration:**

* The `Dockerfile` now downloads the `Figure_To_Pdf.py` script from the specified OMERO Figure release and places it in the appropriate directory for use.
* A new test script, `test_figure_script.sh`, is added to verify that `Figure_To_Pdf.py` is available in the OMERO scripts list.
* The main test script, `test.sh`, is updated to run the new `test_figure_script.sh` as part of the test suite.

**CI/CD improvements:**

* The GitHub Actions workflow (`main.yml`) is updated to support manual triggering via `workflow_dispatch`.

The dependencies for `Figure_To_Pdf.py`  were already included in https://github.com/ome/omero-server-docker/pull/71/changes