### PR TITLE
GitHub actions upgrade

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,8 +32,10 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.name }}
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          driver: docker
       - name: Login to DockerHub
         uses: docker/login-action@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Test
         run: ./test.sh
   upload:
@@ -23,24 +23,24 @@ jobs:
     steps:
       - name: Get other tags
         id: gettags
-        uses: jupyterhub/action-major-minor-tag-calculator@v3
+        uses: jupyterhub/action-major-minor-tag-calculator@v4
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           prefix: "${{ env.name }}:"
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.name }}
       # - name: Set up Docker Buildx
       #   uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Push to Docker Hub
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
           tags: ${{ join(fromJson(steps.gettags.outputs.tags)) }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Ports improvements from https://github.com/ome/omero-web-docker/pull/85 and https://github.com/ome/omero-web-docker/pull/84 to `omero-server-docker`

- bump GitHub actions versions to run on Node.js 24 and no longer use `set-output/save-state` - see https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/ and https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
- set the Docker buildx action with the `docker` driver